### PR TITLE
CDDL for UCCS (and UJCS) and examples in diag

### DIFF
--- a/cddl/claims-set-cbor.cddl
+++ b/cddl/claims-set-cbor.cddl
@@ -1,0 +1,12 @@
+; 
+; Use this with claims-set-common.cddl. All this does is define
+; the Claim Key values.
+iss = 1
+sub = 2
+aud = 3
+exp = 4
+nbf = 5
+iat = 6
+cti = 7
+
+

--- a/cddl/claims-set-common.cddl
+++ b/cddl/claims-set-common.cddl
@@ -1,4 +1,4 @@
-UCCS-message = UCCS-tagged-message / UCCS-untagged-message
+UCCS-Message = UCCS-Tagged-Message / UCCS-Untagged-Message
 
 ; All extensions in $$claims-set-extenstion must comply to this CDDL:
 ;    label = int / text
@@ -19,7 +19,7 @@ claims-set = {
 
 UCCS-tagged-message = #6.601(claims-set)
 
-UCCS-untagged-message = claims-set
+UCCS-Untagged-Message = claims-set
 
 
 iss-claim = (
@@ -27,26 +27,27 @@ iss-claim = (
 )
 
 sub-claim = (
-    sub => tstr,
+    sub => tstr
 )
 
 aud-claim = (
-    aud => tstr,
+    aud => tstr
 )
 
 exp-claim = (
-    exp => ~time,
+    exp => ~time
 )
 
 nbf-claim = (
-    nbf => ~time,
+    nbf => ~time
 )
 
 iat-claim = (
-    iat => ~time,
+    iat => ~time
 )
 
 cti-claim = (
-    cti => bytes,
+    cti => bytes
 )
+
 

--- a/cddl/claims-set-common.cddl
+++ b/cddl/claims-set-common.cddl
@@ -1,0 +1,52 @@
+UCCS-message = UCCS-tagged-message / UCCS-untagged-message
+
+; All extensions in $$claims-set-extenstion must comply to this CDDL:
+;    label = int / text
+;    * label => any
+;
+; That is, they must have a map key/label that is either an int or a text string.
+ 
+claims-set = {
+    ? iss-claim,
+    ? sub-claim,
+    ? aud-claim,
+    ? exp-claim,
+    ? nbf-claim,
+    ? iat-claim,
+    ? cti-claim,
+    * $$claims-set-extension,
+}
+
+UCCS-tagged-message = #6.601(claims-set)
+
+UCCS-untagged-message = claims-set
+
+
+iss-claim = (
+    iss => tstr
+)
+
+sub-claim = (
+    sub => tstr,
+)
+
+aud-claim = (
+    aud => tstr,
+)
+
+exp-claim = (
+    exp => ~time,
+)
+
+nbf-claim = (
+    nbf => ~time,
+)
+
+iat-claim = (
+    iat => ~time,
+)
+
+cti-claim = (
+    cti => bytes,
+)
+

--- a/cddl/claims-set-json.cddl
+++ b/cddl/claims-set-json.cddl
@@ -1,0 +1,10 @@
+; Use this with claim-set-common.cddl. All it does is define the
+; Claim Names for JSON encoding
+iss = "iss"
+sub = "sub"
+aud = "aud"
+exp = "exp"
+nbf = "nbf"
+iat = "iat"
+cti = "cti"
+ 

--- a/cddl/uccs-example.diag
+++ b/cddl/uccs-example.diag
@@ -1,0 +1,9 @@
+/ payload /  {
+    / iss / 1: "coap://as.example.com",
+    / sub / 2: "erikw",
+    / aud / 3: "coap://light.example.com",
+    / exp / 4: 1444064944,
+    / nbf / 5: 1443944944,
+    / iat / 6: 1443944944,
+    / cti / 7: h'0b71'
+}

--- a/cddl/uccs-example.json
+++ b/cddl/uccs-example.json
@@ -1,0 +1,8 @@
+{
+    "iss" : "coap://as.example.com",
+    "sub" : "erikw",
+    "aud" : "coap://light.example.com",
+    "exp" : 1444064944,
+    "nbf" : 1443944944,
+    "iat" : 1443944944
+}


### PR DESCRIPTION
I'm sure there'll be lots of comments...

The examples validate against the CDDL using the cddl command line tool.

I can't ignore JSON in EAT, so a claims-set that doesn't work for JSON is mostly useless to me, so this covers JSON.

I didn't include CWT, though EAT needs that too. I looked at the way CoSWID did CWT, but am not sure that would work for EAT.