### PR TITLE
Provide narrative for the ;# import directive.

### DIFF
--- a/draft-ietf-rats-uccs.md
+++ b/draft-ietf-rats-uccs.md
@@ -454,8 +454,11 @@ CWT-COSE-Key = COSE_Key
 CWT-Encrypted_COSE_Key = COSE_Encrypt / COSE_Encrypt0
 CWT-kid = bytes
 
-;;; insert CDDL from RFC9052 to complete these CDDL definitions.
-;# include RFC9052
+;;; insert CDDL needed from RFC 9052 to complete these CDDL
+;;; definitions, which are not restated here.  This can be done
+;;; manually or automated by a tool that implements a directive such
+;;; as:
+;# import rfc9052
 ~~~
 {: sourcecode-name="uccs-additional-examples.cddl"}
 

--- a/draft-ietf-rats-uccs.md
+++ b/draft-ietf-rats-uccs.md
@@ -454,10 +454,9 @@ CWT-COSE-Key = COSE_Key
 CWT-Encrypted_COSE_Key = COSE_Encrypt / COSE_Encrypt0
 CWT-kid = bytes
 
-;;; insert CDDL needed from RFC 9052 to complete these CDDL
-;;; definitions, which are not restated here.  This can be done
-;;; manually or automated by a tool that implements a directive such
-;;; as:
+;;; Insert the required CDDL from RFC 9052 to complete these
+;;; definitions.  This can be done manually or automated by a
+;;; tool that implements an import directive such as:
 ;# import rfc9052
 ~~~
 {: sourcecode-name="uccs-additional-examples.cddl"}


### PR DESCRIPTION
We do *not* want to restate the below from RFC 9052.

Addressing
https://mailarchive.ietf.org/arch/msg/rats/iQ32uScNs2lcsAm9WJltbYJb894/

``` 
COSE_Key = {
  1 => tstr / int,
  ? 2 => bstr,
  ? 3 => tstr / int,
  ? 4 => [+ tstr / int],
  ? 5 => bstr,
  * label => values, }
COSE_Encrypt = [
  Headers,
  ciphertext: bstr / nil,
  recipients: [+ COSE_recipient],
]
COSE_Encrypt0 = [
  Headers,
  ciphertext: bstr / nil,
]
label = int / tstr
values = any
Headers = (
  protected: empty_or_serialized_map,
  unprotected: header_map,
  )
COSE_recipient = [
  Headers,
  ciphertext: bstr / nil,
  ? recipients: [+ COSE_recipient],
]
empty_or_serialized_map = bstr .cbor header_map / bstr .size 0 header_map = {
  Generic_Headers,
  * label => values, }
Generic_Headers = (
  ? 1 => int / tstr,
  ? 2 => [+ label],
  ? 3 => tstr / int,
  ? 4 => bstr,
  ? (5 => bstr // 6 => bstr),
  )
``` 